### PR TITLE
Using File.separator instead of '\\'

### DIFF
--- a/generators/JavaGenerator/src/main/java/gargl/main/Gargl.java
+++ b/generators/JavaGenerator/src/main/java/gargl/main/Gargl.java
@@ -6,6 +6,8 @@ import gargl.generators.GeneratorFactory;
 import gargl.typedefinitions.GarglModule;
 import gargl.utilities.JCommanderParser;
 
+import java.io.File;
+
 public class Gargl {
 	public static void main(String[] args) {
 
@@ -33,8 +35,8 @@ public class Gargl {
 			// default to current working directory
 			jct.outputDirectory = "";
 		}
-		else if(jct.outputDirectory.charAt(jct.outputDirectory.length() - 1) != '\\') {
-			jct.outputDirectory = jct.outputDirectory + "\\";
+		else if(jct.outputDirectory.charAt(jct.outputDirectory.length() - 1) != File.separatorChar) {
+			jct.outputDirectory = jct.outputDirectory + File.separator;
 		}
 
 		// Read in file and convert to Module containing function name and Requests


### PR DESCRIPTION
Using '\' works on Windows but in Linux/OSX it causes files to be
created as /path/to/file/directory\file.java, where 'directory\file.java'
ends up being the name of the output file instead of just 'file.java'.
