### PR TITLE
compile error fix on Linux with jdk 1.6 =>

### DIFF
--- a/generators/JavaGenerator/pom.xml
+++ b/generators/JavaGenerator/pom.xml
@@ -12,6 +12,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.6</maven.compiler.source>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
The error was :
Parameter.java:[56,18] for-each loops are not supported in -source 1.3
[ERROR](use -source 5 or higher to enable for-each loops)
