### PR TITLE
Added a textarea with response content

### DIFF
--- a/recorders/chrome/Panel/gargl.js
+++ b/recorders/chrome/Panel/gargl.js
@@ -555,13 +555,26 @@
 		if(garglItem.getContent) {
 			garglItem.getContent(function(content, encoding) {
 				window.URL = window.webkitURL || window.URL;
-
+				
+				var responseTextarea = document.getElementById("responseTextarea");
 				var prevLink = document.querySelector('a');
 				if (prevLink) window.URL.revokeObjectURL(prevLink.href);
 
 				var fileContents = content;
 				var bb = new Blob([fileContents], {type: 'text/plain'});
 
+
+				if (responseTextarea) { //if we already added a textare, just change value of it
+					responseTextarea.value = fileContents;		
+				} else { //if we didn't added a textarea yet, add one
+					responseTextarea = document.createElement('input');
+					responseTextarea.type = "textarea";
+					responseTextarea.id = "responseTextarea";
+					responseTextarea.value = fileContents;
+					 
+					document.querySelector(garglViewResponseHolderSelector).appendChild(responseTextarea);
+				}
+				
 				var a = prevLink || document.createElement('a');
 				a.download = "response.txt";
 				a.href = window.URL.createObjectURL(bb);


### PR DESCRIPTION
It was pain for me to just copy the response. So I added a textarea with response content near "View Response" button. It will appear when "View Response" button clicked. Instead of downloading a file, you can simply copy-paste response from that textarea.